### PR TITLE
convert typename to UPPERCASE in reducer.js.hbs

### DIFF
--- a/internals/generators/container/reducer.js.hbs
+++ b/internals/generators/container/reducer.js.hbs
@@ -42,8 +42,9 @@ export const failure = state =>
 
 /* ------------- Hookup Reducers To Types ------------- */
 
+// should convert uppercase to screaming snake_case
 export default createReducer(initialState, {
-  [Types.EVALUATION_REQUEST]: request,
-  [Types.EVALUATION_SUCCESS]: success,
-  [Types.EVALUATION_FAILURE]: failure,
+  [Types.{{ upperCase name }}_REQUEST]: request,
+  [Types.{{ upperCase name }}_SUCCESS]: success,
+  [Types.{{ upperCase name }}_FAILURE]: failure,
 });


### PR DESCRIPTION
createReducer에서 Type.{~~~} 에서 오류가 있어 이를 수정했습니다.
하지만 UPPERCASE도 임시 방편이므로 screaming sake_case로 일일히 수정해야 합니다